### PR TITLE
have dogapi http_client use timeout parameter

### DIFF
--- a/src/dogapi/http/base.py
+++ b/src/dogapi/http/base.py
@@ -68,7 +68,11 @@ class BaseDatadog(object):
             if self.application_key:
                 params['application_key'] = self.application_key
             url = "/api/%s/%s?%s" % (self.api_version, path.lstrip('/'), urlencode(params))
-            conn = self.http_conn_cls(self.api_host, timeout=self.timeout)
+            try:
+                conn = self.http_conn_cls(self.api_host, timeout=self.timeout)
+            except TypeError:
+                # timeout= parameter is only supported 2.6+
+                conn = self.http_conn_cls(self.api_host)
 
             # Construct the body, if necessary
             headers = {}


### PR DESCRIPTION
both `http.client.HTTPSConnection` and `httplib.HTTPSConnection` both accept the `timeout` parameter.

I also considered changing the default constructor parameter for `timeout` to be `None` since that will cause both libraries to use the global default timeout setting.
