### PR TITLE
Remove logging.basicConfig call

### DIFF
--- a/src/dogapi/__init__.py
+++ b/src/dogapi/__init__.py
@@ -1,12 +1,6 @@
 from dogapi.http import DogHttpApi
 from dogapi.stats import DogStatsApi
 
-# make sure there's at least some basic logging configured
-import logging
-logging.basicConfig(
-    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
-)
-
 #FIXME matt: remove the 'dog' variable.
 dog = dog_stats_api = DogStatsApi()
 dog_http_api = DogHttpApi()


### PR DESCRIPTION
Importing dogapi results in a logging.basicConfig() call which can cause problems for application logging config later.

basicConfig() only takes effect once (since it only applies config changes if there are no handlers configured), so it's generally good practise to only call it in the main() of an app before any other logging happens.

Calling logging.info(..) (or other handlers) implicitly calls basicConfig anyway, so it's usually not necessary for a library to call basicConfig to get basic ERROR and WARNING level messages written to stderr if no other logging configuration has been done.
