### PR TITLE
Add fabric output to event text

### DIFF
--- a/examples/fabfile.py
+++ b/examples/fabfile.py
@@ -1,6 +1,7 @@
 """Example of integration between Fabric and Datadog.
 """
 
+from __future__ import with_statement
 from fabric.api import *
 from fabric.colors import *
 from dogapi.fab import setup, notify
@@ -37,5 +38,6 @@ def roles_task(arg_1, arg_2):
 @notify
 def multi_task():
     # return multiple commands results to display their output in the event text
-    commands = ['echo 1', 'echo 2']
-    return [run(cmd) for cmd in commands]
+    commands = ['echo 1', 'ls /wrongdirectory']
+    with settings(warn_only=True):  # capture stdout instead of failing
+        return [run(cmd) for cmd in commands]

--- a/src/dogapi/fab.py
+++ b/src/dogapi/fab.py
@@ -75,7 +75,9 @@ def notify(t):
             if r:
                 if not isinstance(r, list):
                     r = [r]
-                output = '\n\n'.join(['%s\n%s' % (res.command, res.stdout) for res in r])
+                output = '\n\n'.join(['%s\n%s\n%s' %
+                    (res.command, res.stdout, res.stderr) for res in r]
+                )
         except Exception, e:
             error = e
 


### PR DESCRIPTION
- don't display the stdout if not needed
- handle multiple commands output display
- add an example

Fixes #94

Events generated:
![screen shot 2014-05-27 at 6 20 55 pm](https://cloud.githubusercontent.com/assets/1532259/3098665/42e6790c-e5ef-11e3-82b7-9305c1e2a9ae.png)

![screen shot 2014-05-27 at 6 20 34 pm](https://cloud.githubusercontent.com/assets/1532259/3098667/445b4a2e-e5ef-11e3-9914-b6bbdc07ada2.png)

![screen shot 2014-05-27 at 6 28 19 pm](https://cloud.githubusercontent.com/assets/1532259/3098671/47035c26-e5ef-11e3-9fb8-3843d1148b91.png)

![screen shot 2014-05-27 at 6 27 07 pm](https://cloud.githubusercontent.com/assets/1532259/3098668/45bba3aa-e5ef-11e3-845e-068dd46aecd2.png)
This last screenshot shows that the text collapses if it's too long, it's not the actual result of the example command.
