### PR TITLE
Fix statsd exception when tags contain a unicode character

### DIFF
--- a/src/dogapi/stats/statsd.py
+++ b/src/dogapi/stats/statsd.py
@@ -26,6 +26,6 @@ class StatsdAggregator(object):
             if tags:
                 payload += '|#' + ','.join(tags)
             try:
-                self.socket_sendto(payload, self.address)
+                self.socket_sendto(payload.encode('utf-8'), self.address)
             except Exception:
                 logger.exception('couldnt submit statsd point')


### PR DESCRIPTION
`dog_stats_api.increment` and other methods will not work if the `tags` strings contain any non-ASCII characters:

```
   Traceback (most recent call last):
     File "dogapi/stats/statsd.py", line 29, in add_point
       self.socket_sendto(payload, self.address)
   UnicodeEncodeError: 'ascii' codec can't encode character ...
   dd.dogapi: ERROR: couldnt submit statsd point
```

This is a simple fix. Works on Python 2.7 and 3.x.
