### PR TITLE
Fixing ImportError when no ssl module

### DIFF
--- a/src/dogapi/exceptions.py
+++ b/src/dogapi/exceptions.py
@@ -25,6 +25,6 @@ timeout_exceptions = (socket.timeout, )
 
 try:
 	import ssl
-	timeout_exceptions += timeout_exceptions + (ssl.SSLError, )
+	timeout_exceptions += (ssl.SSLError, )
 except ImportError:
 	pass


### PR DESCRIPTION
This allows import in Google App Engine, where no ssl module is
available.
