### PR TITLE
dogwrap: decode process output as utf-8

### DIFF
--- a/src/dogshell/wrap.py
+++ b/src/dogshell/wrap.py
@@ -136,6 +136,10 @@ def main():
         event_body.extend([u'notifications: %s\n' % (notifications)])
 
     event_body.append(u'%%%\n')
+
+    # ensure all strings are parsed as utf-8
+    event_body = [x.decode('utf-8') for x in event_body]
+
     event_body = u''.join(event_body)
     event = {
         'alert_type': alert_type,


### PR DESCRIPTION
This fixes the issue where dogwrap will crash when a process' stdout/stderr contains non-ascii characters, in most cases utf-8.

I was getting this error: 
```
$ python -m dogshell.wrap 'echo "\xE2\x98\xA0"'
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Library/Python/2.7/site-packages/dogshell/wrap.py", line 155, in <module>
    main()
  File "/Library/Python/2.7/site-packages/dogshell/wrap.py", line 139, in main
    event_body = u''.join(event_body)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 0: ordinal not in range(128)
```

With this change:
```
$ python -m dogshell.wrap 'echo "\xE2\x98\xA0"'

☠
```