### PR TITLE
fix(stream): cast timestamps as ints

### DIFF
--- a/src/dogapi/http/events.py
+++ b/src/dogapi/http/events.py
@@ -35,8 +35,8 @@ class EventApi(object):
         }
         """
         params = {
-            'start': start,
-            'end': end,
+            'start': int(start),
+            'end': int(end),
         }
         if priority:
             params['priority'] = priority


### PR DESCRIPTION
python datetime/time timestamps will sometimes be floats, such as when you do this:

    >>> time.mktime(datetime.datetime.now().timetuple())

The HTTP throws non-specified errors when these are passed. Casting them as int() resolves this.